### PR TITLE
Add release artifact upload on tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,3 +47,9 @@ jobs:
         with:
           name: firmware
           path: SHIELD_NAME_BOARD_NAME.uf2
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            SHIELD_NAME_BOARD_NAME.uf2


### PR DESCRIPTION
Great work on this project! I love the use of GitHub actions for the build process and was interested in adding the ability to make more "official" releases of my configuration over time that would be more static/long lasting and easy to revert back to previous working versions.

*Note*: This GitHub action used to be maintained by GitHub (https://github.com/actions/upload-release-asset) but active development has moved to this new repository (https://github.com/softprops/action-gh-release). So while it's not maintained by the official GitHub developers anymore, this repository is very active and seems to be promoted by the official actions account so should be reliable and long living.

Basically it checks to see if the action is building on a "tag" (created with something like `git tag v1.0`) and if it is, then it will create a release and upload the firmware as a release artifact. If it is just a normal push/PR to any branch then this step is skipped all together.

Let me know if this would be a worthy/useful addition to the standard configuration template. I have just found it useful in my workflow and figured it would provide a good way for packaging official configuration versions for something like the Nice!60 board (https://github.com/Nice-Keyboards/nice60-zmk-config) in the future.